### PR TITLE
fix: apply proxy url in runner

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -357,6 +357,11 @@ func buildProtocolRequest(colReq *collection.Request) *protocol.Request {
 		}
 	}
 
+	// Proxy
+	if colReq.ProxyURL != "" {
+		req.ProxyURL = colReq.ProxyURL
+	}
+
 	// Body
 	if colReq.Body != nil && colReq.Body.Content != "" {
 		req.Body = []byte(colReq.Body.Content)


### PR DESCRIPTION
## Summary

Per-request proxy_url field exists in the collection schema and the HTTP client already supports it, but buildProtocolRequest() in the runner never copies it from the collection request to the protocol request. This means proxy_url set in .gottp.yaml files is silently ignored in both headless and TUI mode.

## Changes

- Copy ProxyURL from collection request to protocol request in buildProtocolRequest()

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] All existing tests pass (`make test`)
- [ ] New tests added for changes
- [ ] Linter passes (`make lint`)
- [ ] Manually tested in headless CLI mode (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
